### PR TITLE
Save executed GTID set as replicator position

### DIFF
--- a/internal/bridge/sync.go
+++ b/internal/bridge/sync.go
@@ -88,24 +88,15 @@ func (h *eventHandler) OnRow(e *canal.RowsEvent) error {
 	return h.bridge.ctx.Err()
 }
 
-func (h *eventHandler) OnGTID(set mysql.GTIDSet) error {
-	if h.gtidMode {
-		h.bridge.syncCh <- &savePos{
-			pos:   newGTIDSet(set),
-			force: false,
-		}
-	}
-
+func (h *eventHandler) OnGTID(_ mysql.GTIDSet) error {
 	return h.bridge.ctx.Err()
 }
 
 func (h *eventHandler) OnPosSynced(pos mysql.Position, set mysql.GTIDSet, force bool) error {
 	if h.gtidMode {
-		if force && !emptyGTID.Equal(set) {
-			h.bridge.syncCh <- &savePos{
-				pos:   newGTIDSet(set),
-				force: force,
-			}
+		h.bridge.syncCh <- &savePos{
+			pos:   newGTIDSet(set),
+			force: force,
 		}
 	} else {
 		h.bridge.syncCh <- &savePos{

--- a/internal/bridge/testdata/cfg.yml
+++ b/internal/bridge/testdata/cfg.yml
@@ -15,7 +15,7 @@ replication:
 
   mysql:
     dump:
-      exec_path: '/usr/bin/mysqldump'
+      exec_path: ''
       skip_master_data: false
       extra_options:
         - '--column-statistics=0'


### PR DESCRIPTION
On reconnecting to MySQL master replicator crashed with error that master has purged
required GTID. The problem was how we synced and saved actual position:
it was just last executed GTID, but an executed GTID set.