### PR TITLE
Added new replication state to metrics: dumping

### DIFF
--- a/internal/bridge/replicator_test.go
+++ b/internal/bridge/replicator_test.go
@@ -177,7 +177,15 @@ func (s *bridgeSuite) TestDump() {
 		}
 	}()
 
+	assert.Eventually(t, s.bridge.Dumping, 100*time.Millisecond, 5*time.Millisecond)
+	assert.False(t, s.bridge.Running())
+
 	<-s.bridge.canal.WaitDumpDone()
+
+	assert.Eventually(t, func() bool {
+		return !s.bridge.Dumping()
+	}, 100*time.Millisecond, 5*time.Millisecond)
+	assert.True(t, s.bridge.Running())
 
 	require.Eventually(t, func() bool {
 		return s.hasSyncedData("users", uint64(tuples))
@@ -185,6 +193,9 @@ func (s *bridgeSuite) TestDump() {
 
 	err := s.bridge.Close()
 	assert.NoError(t, err)
+
+	assert.False(t, s.bridge.Dumping())
+	assert.False(t, s.bridge.Running())
 }
 
 func (s *bridgeSuite) TestReplication() {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -2,6 +2,14 @@ package metrics
 
 import "github.com/prometheus/client_golang/prometheus"
 
+type ReplState int8
+
+const (
+	StateStopped ReplState = iota
+	StateDumping
+	StateRunning
+)
+
 var (
 	secondsBehindMaster = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: "mysql2tarantool",
@@ -12,7 +20,7 @@ var (
 	replState = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: "mysql2tarantool",
 		Name:      "state",
-		Help:      "The replication running state: 0=stopped, 1=ok",
+		Help:      "The replication running state: 0=stopped, 1=dumping, 2=running",
 	})
 )
 
@@ -25,10 +33,6 @@ func SetSecondsBehindMaster(value uint32) {
 	secondsBehindMaster.Set(float64(value))
 }
 
-func SetReplicationState(state bool) {
-	v := 0
-	if state {
-		v = 1
-	}
-	replState.Set(float64(v))
+func SetReplicationState(state ReplState) {
+	replState.Set(float64(state))
 }


### PR DESCRIPTION
It allows to monitor the replication state more accurate:

```
0 = stopped
1 = dumping
2 = running
```